### PR TITLE
Improve simple normalizing

### DIFF
--- a/lib/typecheck.ml
+++ b/lib/typecheck.ml
@@ -5,7 +5,7 @@
 open Common
 open Printf
 open Term
-   
+
 type tc_def =
   | TCCellDef of cell_term
   | TCTermDef of ctx * ty_term * tm_term
@@ -16,7 +16,7 @@ type tc_env = {
   }
 
 let empty_env = { gma = [] ; rho = [] }
-              
+
 (* The typechecking monad *)
 type 'a tcm = tc_env -> 'a err
 
@@ -25,7 +25,7 @@ let ( >>= ) m f env =
   match m env with
   | Fail s -> Fail s
   | Succeed a -> f a env
-               
+
 let tc_ok a _ = Succeed a
 let tc_fail msg _ = Fail msg
 let tc_in_ctx g m env = m { env with gma = g }
@@ -38,18 +38,18 @@ let tc_with_var id ty m env = m { env with gma = (id, ty) :: env.gma }
 let tc_with_vars vars m env = m { env with gma = vars @ env.gma }
 let tc_ctx_vars env = Succeed (List.map fst env.gma)
 let tc_lift m_err _ = m_err
-                    
+
 let tc_try m f_ok f_fail env =
   match m with
   | Fail msg -> f_fail msg env
   | Succeed a -> f_ok a env
-                    
+
 let rec tc_traverse f = function
   | [] -> tc_ok []
   | (x::xs) -> tc_traverse f xs >>= fun rs ->
                f x >>= fun r ->
                tc_ok (r::rs)
-                    
+
 (* Lookup and identifier in the context *)
 let tc_lookup_var ident env =
   try Succeed (List.assoc ident env.gma)
@@ -108,78 +108,87 @@ let rec tc_pd_kth_tgt k pd =
 let tc_pd_src pd = tc_pd_kth_src ((dim_of_pd pd) - 1) pd
 let tc_pd_tgt pd = tc_pd_kth_tgt ((dim_of_pd pd) - 1) pd
 
+let rec tc_traverse_with_int f xs n =
+  match xs with
+  | [] -> tc_ok ([], n)
+  | x :: xs -> f x n >>= fun (y, k) ->
+               tc_traverse_with_int f xs k >>= fun (ys, k') ->
+               tc_ok (y :: ys, k')
+
+
+
 (* Basic normalization (unfold definitions, uniquify pd's *)
-let rec tc_simple_ty_nf ty =
+let rec tc_simple_ty_nf ty n =
   match ty with
-  | ObjT -> tc_ok ObjT
+  | ObjT -> tc_ok (ObjT, n)
   | ArrT (ty', src, tgt) ->
-     tc_simple_ty_nf ty' >>= fun ty_nf ->
-     tc_simple_tm_nf src >>= fun src_nf ->
-     tc_simple_tm_nf tgt >>= fun tgt_nf ->
-     tc_ok (ArrT (ty_nf, src_nf, tgt_nf))
-     
-and tc_simple_tm_nf tm =
+     tc_simple_ty_nf ty' n >>= fun (ty_nf, k) ->
+     tc_simple_tm_nf src k >>= fun (src_nf, k1) ->
+     tc_simple_tm_nf tgt k1 >>= fun (tgt_nf, k2) ->
+     tc_ok (ArrT (ty_nf, src_nf, tgt_nf), k2)
+
+and tc_simple_tm_nf tm n =
   match tm with
-  | VarT id -> tc_ok (VarT id)
+  | VarT id -> tc_ok (VarT id, n)
   | DefAppT (id, args) ->
-     tc_lookup_def id >>= fun def -> 
+     tc_lookup_def id >>= fun def ->
      (match def with
       | TCCellDef cell_tm ->
-         tc_traverse (tc_simple_tm_nf) args >>= fun args_nf -> 
-         tc_simple_cell_nf cell_tm >>= fun cell_nf ->
-         tc_ok (CellAppT (cell_nf, args_nf))
+         tc_traverse_with_int tc_simple_tm_nf args n >>= fun (args_nf, k) ->
+         tc_simple_cell_nf cell_tm k >>= fun (cell_nf, k1) ->
+         tc_ok (CellAppT (cell_nf, args_nf), k1)
       | TCTermDef (tele, _, term) ->
          (* The order here may be inefficient, but is currently necessary,
           * as normalization will rename all the pasting diagram variables
           * so that the names in "tele" no longer correspond correctly.
-          * By first performing the substitution, we avoid this problem. 
+          * By first performing the substitution, we avoid this problem.
           *)
          let sub = List.combine (List.map fst tele) args in
          let sub_tm = subst_tm sub term in
-         tc_simple_tm_nf sub_tm
+         tc_simple_tm_nf sub_tm n
      )
   | CellAppT (cell, args) ->
-     tc_traverse (tc_simple_tm_nf) args >>= fun args_nf -> 
-     tc_simple_cell_nf cell >>= fun cell_nf ->
-     tc_ok (CellAppT (cell_nf, args_nf))
-     
-and tc_simple_cell_nf cell =
+     tc_traverse_with_int tc_simple_tm_nf args n >>= fun (args_nf, k) ->
+     tc_simple_cell_nf cell k >>= fun (cell_nf, k1) ->
+     tc_ok (CellAppT (cell_nf, args_nf), k1)
+
+and tc_simple_cell_nf cell n =
   match cell with
   | CohT (pd, typ) ->
-     tc_uniquify_pd pd >>= fun (pd_nf, s, _) ->
-     tc_simple_ty_nf (subst_ty s typ) >>= fun ty_nf ->
-     tc_ok (CohT (pd_nf, ty_nf))
+     tc_uniquify_pd pd n >>= fun (pd_nf, s, k) ->
+     tc_simple_ty_nf (subst_ty s typ) k >>= fun (ty_nf, k1) ->
+     tc_ok (CohT (pd_nf, ty_nf), k1)
   | CompT (pd, typ) ->
-     tc_uniquify_pd pd >>= fun (pd_nf, s, _) ->
-     tc_simple_ty_nf (subst_ty s typ) >>= fun ty_nf ->
-     tc_ok (CompT (pd_nf, ty_nf))
-                     
-and tc_uniquify_pd pd =
+     tc_uniquify_pd pd n >>= fun (pd_nf, s, k) ->
+     tc_simple_ty_nf (subst_ty s typ) k >>= fun (ty_nf, k1) ->
+     tc_ok (CompT (pd_nf, ty_nf), k1)
+
+and tc_uniquify_pd pd n =
   match pd with
   | (id, ObjT) :: [] ->
-     let obj_id = "x0" in 
-     tc_ok ((obj_id, ObjT)::[], (id, VarT obj_id)::[], 1)
+     let obj_id = sprintf "x%d" n in
+     tc_ok ((obj_id, ObjT)::[], (id, VarT obj_id)::[], n + 1)
   | (fill_id, fill_typ) :: (tgt_id, tgt_typ) :: pd' ->
-     tc_uniquify_pd pd' >>= fun (upd, sub, k) ->
-     let tgt_id' = sprintf "x%d" k in 
+     tc_uniquify_pd pd' n >>= fun (upd, sub, k) ->
+     let tgt_id' = sprintf "x%d" k in
      let fill_id' = sprintf "x%d" (k+1) in
      let tgt_typ' = subst_ty sub tgt_typ in
-     let fill_typ' = subst_ty ((tgt_id,VarT tgt_id')::sub) fill_typ in 
+     let fill_typ' = subst_ty ((tgt_id,VarT tgt_id')::sub) fill_typ in
      tc_ok ((fill_id', fill_typ')::(tgt_id', tgt_typ')::upd,
             (fill_id, VarT fill_id')::(tgt_id, VarT tgt_id')::sub,k+2)
   | _ -> tc_fail "Internal error: invalid pasting diagram"
 
 (* Compare types and terms up to simple normalization *)
 let tc_eq_nf_ty ty_a ty_b =
-  tc_simple_ty_nf ty_a >>= fun ty_a_nf ->
-  tc_simple_ty_nf ty_b >>= fun ty_b_nf ->
+  tc_simple_ty_nf ty_a 0 >>= fun (ty_a_nf, _) ->
+  tc_simple_ty_nf ty_b 0 >>= fun (ty_b_nf, _) ->
   tc_ok (ty_a_nf = ty_b_nf)
 
 let tc_eq_nf_tm tm_a tm_b =
-  tc_simple_tm_nf tm_a >>= fun tm_a_nf ->
-  tc_simple_tm_nf tm_b >>= fun tm_b_nf ->
+  tc_simple_tm_nf tm_a 0 >>= fun (tm_a_nf, _) ->
+  tc_simple_tm_nf tm_b 0 >>= fun (tm_b_nf, _) ->
   tc_ok (tm_a_nf = tm_b_nf)
-    
+
 (*
  * Typechecking Internal Terms
  *)
@@ -188,15 +197,15 @@ let rec tc_check_ty t =
   match t with
   | ObjT -> tc_ok ObjT
   | ArrT (typ, src, tgt) ->
-     tc_check_ty typ >>= fun typ' -> 
+     tc_check_ty typ >>= fun typ' ->
      tc_check_tm src typ' >>= fun src_tm ->
-     tc_check_tm tgt typ' >>= fun tgt_tm -> 
+     tc_check_tm tgt typ' >>= fun tgt_tm ->
      tc_ok (ArrT (typ', src_tm, tgt_tm))
 
 and tc_check_tm tm ty =
   tc_infer_tm tm >>= fun (tm', ty') ->
-  tc_simple_ty_nf ty >>= fun ty_a ->
-  tc_simple_ty_nf ty' >>= fun ty_b -> 
+  tc_simple_ty_nf ty 0 >>= fun (ty_a, _) ->
+  tc_simple_ty_nf ty' 0 >>= fun (ty_b, _) ->
   if (ty_a = ty_b) then tc_ok tm' else
     let msg = sprintf "The term %s was expected to have type %s,
                        but was inferred to have type %s"
@@ -206,27 +215,27 @@ and tc_check_tm tm ty =
 
 and tc_infer_tm tm =
   match tm with
-  | VarT id -> 
+  | VarT id ->
      tc_lookup_var id >>= fun typ ->
      tc_ok (VarT id, typ)
   | DefAppT (id, args) ->
      tc_lookup_def id >>= fun def ->
      (match def with
-      | TCCellDef cell_tm -> 
+      | TCCellDef cell_tm ->
          let pd = cell_pd cell_tm in
          tc_check_args args pd >>= fun sub ->
-         let typ = subst_ty sub (cell_typ cell_tm) in 
+         let typ = subst_ty sub (cell_typ cell_tm) in
          tc_ok (DefAppT (id, List.map snd sub), typ)
-      | TCTermDef (tele, typ, _) -> 
+      | TCTermDef (tele, typ, _) ->
          tc_check_args args tele >>= fun sub ->
          let typ' = subst_ty sub typ in
          tc_ok (DefAppT (id, List.map snd sub), typ')
      )
   | CellAppT (cell, args) ->
      tc_check_cell cell >>= fun cell_tm ->
-     let pd = cell_pd cell_tm in 
+     let pd = cell_pd cell_tm in
      tc_check_args args pd >>= fun sub ->
-     let typ = subst_ty sub (cell_typ cell_tm) in 
+     let typ = subst_ty sub (cell_typ cell_tm) in
      tc_ok (CellAppT (cell_tm, List.map snd sub), typ)
 
 and tc_check_ctx ctx =
@@ -238,7 +247,7 @@ and tc_check_ctx ctx =
      tc_ok ((id,typ_tm)::g)
 
 and tc_check_args args ctx =
-  match (args, ctx) with 
+  match (args, ctx) with
   | (_::_, []) -> tc_fail "Too many arguments!"
   | ([], _::_) -> tc_fail "Not enough arguments!"
   | ([], []) -> tc_ok []
@@ -247,10 +256,10 @@ and tc_check_args args ctx =
      let arg_typ' = subst_ty sub arg_typ in
      tc_check_tm arg_tm arg_typ' >>= fun arg_tm' ->
      tc_ok ((id, arg_tm') :: sub)
-     
+
 and tc_check_cell cell =
   match cell with
-  | CohT (pd, typ) -> 
+  | CohT (pd, typ) ->
      tc_check_pd pd >>= fun (pd', _, _) ->
      tc_with_vars pd' (tc_check_ty typ) >>= fun typ' ->
      let pd_vars = SS.of_list (List.map fst pd') in
@@ -265,7 +274,7 @@ and tc_check_cell cell =
      tc_pd_tgt pd' >>= fun pd_tgt ->
      tc_with_vars pd_src (tc_infer_tm src) >>= fun (src_tm, src_typ) ->
      tc_with_vars pd_tgt (tc_infer_tm tgt) >>= fun (tgt_tm, tgt_typ) ->
-     tc_eq_nf_ty src_typ tgt_typ >>= fun nf_match -> 
+     tc_eq_nf_ty src_typ tgt_typ >>= fun nf_match ->
      if (not nf_match) then
        tc_fail "Source and target do not have the same type"
      else let pd_src_vars = SS.of_list (List.map fst pd_src) in
@@ -288,9 +297,9 @@ and tc_check_pd pd =
      tc_in_ctx res_pd (tc_check_ty tgt_typ)                   >>= fun tgt_typ_tm ->
      tc_in_ctx ((tgt_id, tgt_typ_tm) :: res_pd)
                (tc_check_ty fill_typ)                         >>= fun fill_typ_tm ->
-     let cvars = List.map fst res_pd in 
+     let cvars = List.map fst res_pd in
      let codim = (dim_of ptyp) - (dim_of tgt_typ_tm) in
-     tc_tgt_of (VarT pid) ptyp codim                          >>= fun (src_tm_tm, src_typ_tm) -> 
+     tc_tgt_of (VarT pid) ptyp codim                          >>= fun (src_tm_tm, src_typ_tm) ->
      if (tgt_typ_tm <> src_typ_tm) then
        let msg = sprintf "Type error: %s =/= %s"
                          (print_ty_term tgt_typ_tm) (print_ty_term src_typ_tm) in
@@ -304,11 +313,11 @@ and tc_check_pd pd =
        tc_fail (sprintf "Fill and target cell have the same identifier: %s" fill_id)
      else if (List.mem fill_id cvars) then
        tc_fail (sprintf "Filling identifier %s already exists" fill_id)
-     else if (List.mem tgt_id cvars) then 
+     else if (List.mem tgt_id cvars) then
        tc_fail (sprintf "Target identifier %s already exists" tgt_id)
      else tc_ok ((fill_id, fill_typ_tm) :: (tgt_id, tgt_typ_tm) :: res_pd, fill_id, fill_typ_tm)
 
-(* Return the unbiased composite of a pasting diagram *)     
+(* Return the unbiased composite of a pasting diagram *)
 let rec tc_ucomp pd =
   tc_try (is_disc_pd pd)
          (fun (id, ty) -> tc_ok (VarT id, ty))
@@ -316,10 +325,10 @@ let rec tc_ucomp pd =
                    tc_pd_tgt pd >>= fun pd_tgt ->
                    tc_ucomp pd_src >>= fun (uc_src, uc_typ) ->
                    tc_ucomp pd_tgt >>= fun (uc_tgt, _) ->
-                   let next_ty = ArrT (uc_typ, uc_src, uc_tgt) in 
+                   let next_ty = ArrT (uc_typ, uc_src, uc_tgt) in
                    tc_ok (CellAppT (CompT (pd, next_ty), id_args pd), next_ty))
 
-(* Return the identity coherence applied to a given term *)         
+(* Return the identity coherence applied to a given term *)
 let tc_tm_get_id tm =
   tc_infer_tm tm >>= fun (_, ty) ->
   let args = tm_to_disc_sub tm ty in
@@ -343,13 +352,13 @@ let rec tc_tm_kth_src k tm =
   if (k <= 0) then tc_ok tm
   else tc_tm_kth_src (k-1) tm >>= fun t ->
        tc_tm_src t
-                         
+
 let rec tc_tm_kth_tgt k tm =
   if (k <= 0) then tc_ok tm
   else tc_tm_kth_tgt (k-1) tm >>= fun t ->
        tc_tm_tgt t
-  
-(* 
+
+(*
  * Pruning
  *)
 
@@ -362,7 +371,7 @@ let rec tc_app_zip_prune_to_end z typ =
                               (fun _ -> (* printf "Pruning identity coherence.\n";
                                         printf "Term was: %s\n" (print_tm_term (app_zip_head_tm z')); *)
                                         tc_lift (app_zip_drop z') >>= fun (zd, s) ->
-                                        let typ' = subst_ty s typ in 
+                                        let typ' = subst_ty s typ in
                                         tc_app_zip_prune_to_end zd typ')
                               (fun _ -> (* printf "Not an identity coherence.\n"; *)
                                         tc_app_zip_prune_to_end z' typ)
@@ -373,7 +382,7 @@ let rec tc_app_zip_prune_to_end z typ =
 
 let rec tc_prune_cell pd typ args =
   let pd_w_args = List.combine pd args in
-  tc_lift (zipper_open_right pd_w_args) >>= fun z -> 
+  tc_lift (zipper_open_right pd_w_args) >>= fun z ->
   tc_app_zip_prune_to_end z typ >>= fun (zp, typ') ->
   let pruned_pd_w_args = zipper_close zp in
   let (pd', args') = List.split pruned_pd_w_args in
@@ -384,8 +393,8 @@ let rec tc_prune_cell pd typ args =
   else tc_ok (pd', typ', args')
   (* tc_ok (pd', typ', args') *)
 
-  
-(* We prune coherences.  Is this legit? *)  
+
+(* We prune coherences.  Is this legit? *)
 let tc_prune tm =
   match tm with
   | CellAppT (CompT (pd, typ), args) ->
@@ -396,10 +405,10 @@ let tc_prune tm =
      tc_ok (CellAppT (CohT (pd', typ'), args'))
   | _ -> tc_ok tm
 
-(* 
+(*
  * Rectification
  *)
-       
+
 let tc_rectify tm =
   (* printf "Rectifying term: %s\n" (print_tm_term tm); *)
   match tm with
@@ -409,7 +418,7 @@ let tc_rectify tm =
             (fun _ -> (* printf "Got a unary composite!\n";  *)
                       let arg = List.hd args in
                       (* printf "Head term is: %s\n" (print_tm_term arg); *)
-                      tc_ok arg)  
+                      tc_ok arg)
             (fun _ -> tc_try (is_endomorphism_coh cell)
                              (fun (pd, tm, ty) ->
                                (* printf "Got an endo-coherence!\n"; *)
@@ -418,14 +427,14 @@ let tc_rectify tm =
                                 * this term after substituting the arguments. *)
                                let sub = List.combine (List.map fst pd) args in
                                let tm' = subst_tm sub tm in
-                               let ty' = subst_ty sub ty in 
+                               let ty' = subst_ty sub ty in
                                let id_args = tm_to_disc_sub tm' ty' in
                                let id_coh = id_coh (dim_of ty') in
                                let result = CellAppT (id_coh, id_args) in
                                (* printf "Result: %s\n" (print_tm_term result); *)
                                tc_ok result)
                              (fun _ -> tc_ok tm))
-  | _ -> tc_ok tm 
+  | _ -> tc_ok tm
 
 (*
  * Full Normalization (assumes cell is already simply normalized ...)
@@ -439,7 +448,7 @@ let rec tc_full_normalize_ty ty =
      tc_full_normalize_tm src >>= fun src_nf ->
      tc_full_normalize_tm tgt >>= fun tgt_nf ->
      tc_ok (ArrT (typ_nf, src_nf, tgt_nf))
-       
+
 and tc_full_normalize_tm tm =
   match tm with
   | VarT id -> tc_ok (VarT id)
@@ -481,15 +490,15 @@ let rec tc_promote pd btyp u v ftyp f =
   match btyp with
   | ObjT -> tc_ok (f,ftyp)
   | ArrT (btyp', su, tu) ->
-    tc_promote pd btyp' su tu ftyp f >>= fun (fp, fp_typ) -> 
+    tc_promote pd btyp' su tu ftyp f >>= fun (fp, fp_typ) ->
     let k = dim_of btyp in
     let n = dim_of ftyp in
     let codim = n - k in
-    tc_lift (pad_pd (k+1) n) >>= fun ppd -> 
+    tc_lift (pad_pd (k+1) n) >>= fun ppd ->
     tc_ucomp ppd >>= fun (pcoh, _) ->
     (* Which pd to use here? *)
     tc_pd_kth_src codim pd >>= fun u_pd ->
-    tc_pd_kth_tgt codim pd >>= fun v_pd -> 
+    tc_pd_kth_tgt codim pd >>= fun v_pd ->
     tc_normalizer u_pd u btyp >>= fun (pu, pu_typ) ->
     tc_normalizer v_pd v btyp >>= fun (pv, pv_typ) ->
     tc_invert_coh pv >>= fun pv_inv ->
@@ -500,8 +509,8 @@ let rec tc_promote pd btyp u v ftyp f =
     | CellAppT (cell, _) ->
        let result = CellAppT (cell, args) in
        let pd = cell_pd cell in
-       let sub = List.combine (List.map fst pd) args in 
-       let result_typ = subst_ty sub (cell_typ cell) in 
+       let sub = List.combine (List.map fst pd) args in
+       let result_typ = subst_ty sub (cell_typ cell) in
        (* printf "Finished promotion with: %s\n" (print_tm_term result); *)
        tc_ok (result, result_typ)
     | _ -> tc_fail "internal error"
@@ -513,8 +522,8 @@ let rec tc_promote pd btyp u v ftyp f =
   (*    tc_check_args args pd >>= fun sub -> *)
   (*    let typ = subst_ty sub (cell_typ cell_tm) in  *)
   (*    tc_ok (CellAppT (cell_tm, List.map snd sub), typ) *)
-         
-(* In principle, we do not actually need to normalize the 
+
+(* In principle, we do not actually need to normalize the
  * term here, as the normalization should have been available
  * above directly from the type of f....
  *)
@@ -527,6 +536,6 @@ and tc_normalizer pd tm typ =
   | ArrT (typ',s,t) ->
      tc_promote pd typ' s t typ tm' >>= fun (promo, _) ->
      let nmlzr = CellAppT (CohT (pd, ArrT(typ,tm,promo)),
-                           (List.map (fun (id, _) -> VarT id) pd)) in 
-     let nmlzr_typ = ArrT (typ,tm,promo) in 
+                           (List.map (fun (id, _) -> VarT id) pd)) in
+     let nmlzr_typ = ArrT (typ,tm,promo) in
      tc_ok (nmlzr, nmlzr_typ)


### PR DESCRIPTION
Changed simple normalization so that each variable gets a unique name throughout the whole term instead of just within the pasting diagram.

Most of the changes appear to be whitespace changes which got accidently added

I don't know if this messes with what you are trying to do so feel free to reject this. `demo.catt` does not seem to typecheck with this but I believe the problem started earlier